### PR TITLE
Allow customizing overlap fix per image group

### DIFF
--- a/bake.py
+++ b/bake.py
@@ -1230,7 +1230,6 @@ class BakeButton(bpy.types.Operator):
 
             # Scale up textures most likely to be looked closer at (in this case, eyes)
             if prioritize_face and pack_uvs:
-                # Apply prioritize_face per-object using group overrides
                 for obj in get_objects(collection.all_objects, {"MESH"}):
                     # Build set of relevant vertices
                     affected_vertices = set()

--- a/bake.py
+++ b/bake.py
@@ -534,28 +534,19 @@ class BakeButton(bpy.types.Operator):
         filter_input, filter_output = filter_create(context, tree, matgroupnum)
         tree.links.new(filter_input, image_node.outputs["Image"])
         viewer_node = tree.nodes.new(type="CompositorNodeComposite")
-        # Link alpha only if both nodes expose an Alpha socket (some setups/versions may not)
-        if "Alpha" in viewer_node.inputs and "Alpha" in image_node.outputs:
-            try:
-                tree.links.new(viewer_node.inputs["Alpha"], image_node.outputs["Alpha"])
-            except Exception:
-                # ignore any linking errors and continue
-                pass
+        try:
+            tree.links.new(viewer_node.inputs["Alpha"], image_node.outputs["Alpha"])
+        except Exception:
+            # ignore any linking errors and continue
+            print("Error linking alpha input to viewer node, continuing without it.")
+            pass
 
-        # Link image output to the composite node. If the standard 'Image' input is missing,
-        # fall back to the first available input to avoid crashes.
-        if "Image" in viewer_node.inputs:
-            try:
-                tree.links.new(viewer_node.inputs["Image"], filter_output)
-            except Exception:
-                pass
-        else:
-            # fallback: try linking to index 0 input if present
-            try:
-                if len(viewer_node.inputs) > 0:
-                    tree.links.new(viewer_node.inputs[0], filter_output)
-            except Exception:
-                pass
+        try:
+            tree.links.new(viewer_node.inputs["Image"], filter_output)
+        except Exception:
+            print("Error linking image input to viewer node, continuing without it.")
+            pass
+
 
         # rerender image
         context.scene.render.resolution_x = bpy.data.images[image].size[0]

--- a/properties.py
+++ b/properties.py
@@ -305,6 +305,33 @@ def register_properties():
             max=30
         )
     register_class(MaterialListGrouper)
+
+    class MaterialGroupSettings(PropertyGroup):
+        group_number: IntProperty(
+            name="Group Number",
+            default=0,
+            min=0,
+            max=999
+        )
+        uv_overlap_correction: EnumProperty(
+            name=t('Scene.bake_uv_overlap_correction.label'),
+            description=t('Scene.bake_uv_overlap_correction.desc'),
+            items=[
+                ("INHERIT", "Inherit", "Use scene default"),
+                ("NONE", t("Scene.bake_uv_overlap_correction.none.label"), t("Scene.bake_uv_overlap_correction.none.desc")),
+                ("UNMIRROR", t("Scene.bake_uv_overlap_correction.unmirror.label"), t("Scene.bake_uv_overlap_correction.unmirror.desc")),
+                ("REPROJECT", t("Scene.bake_uv_overlap_correction.reproject.label"), t("Scene.bake_uv_overlap_correction.reproject.desc")),
+                ("MANUAL", t('BakePanel.manual.label'), t('BakePanel.manual.desc')),
+                ("MANUALNOPACK", t('BakePanel.manual_no_pack.label'), t('BakePanel.manual_no_pack.desc')),
+            ],
+            default="INHERIT",
+        )
+        prioritize_face: BoolProperty(
+            name=t('Scene.bake_prioritize_face.label'),
+            description=t('Scene.bake_prioritize_face.desc'),
+            default=False
+        )
+    register_class(MaterialGroupSettings)
     
     
     
@@ -313,6 +340,11 @@ def register_properties():
         type=MaterialListGrouper
     )
     Scene.bake_material_groups_index = IntProperty(default=0)
+
+    Scene.material_group_settings = CollectionProperty(
+        type=MaterialGroupSettings
+    )
+    Scene.material_group_settings_index = IntProperty(default=0)
         
     Scene.bake_resolution = IntProperty(
         name=t('Scene.bake_resolution.label'),

--- a/properties.py
+++ b/properties.py
@@ -326,11 +326,6 @@ def register_properties():
             ],
             default="INHERIT",
         )
-        prioritize_face: BoolProperty(
-            name=t('Scene.bake_prioritize_face.label'),
-            description=t('Scene.bake_prioritize_face.desc'),
-            default=False
-        )
     register_class(MaterialGroupSettings)
     
     

--- a/ui.py
+++ b/ui.py
@@ -103,10 +103,6 @@ class Material_Grouping_UL_List(UIList):
             col.label(text=item.name, icon = custom_icon)
             col = row.column()
             col.prop(item, "group", text=t('BakePanel.material_grouping.label'))
-            # per-group overrides
-            col = row.column()
-            col.prop(item, "uv_overlap_correction", text="UV Fix")
-            col.prop(item, "prioritize_face", text=t('Scene.bake_prioritize_face.label'))
             #col = row.column()
             #col.prop(item, "include", text="include")
         elif self.layout_type in {'GRID'}:
@@ -131,7 +127,20 @@ class Material_Group_Settings_List(UIList):
         row = layout.row(align=True)
         row.label(text=str(item.group_number))
         row.prop(item, 'uv_overlap_correction', text='')
-        row.prop(item, 'prioritize_face', text='')
+        # delete operator
+        row.operator("tuxedo_bake.material_group_settings_delete", text="", icon='X', emboss=False).index = index
+        
+@wrapper_registry
+class Material_Group_Settings_Delete(Operator):
+    bl_idname = "tuxedo_bake.material_group_settings_delete"
+    bl_label = "Delete Material Group Settings"
+    bl_options = {'INTERNAL'}
+
+    index: bpy.props.IntProperty()
+
+    def execute(self, context):
+        context.scene.material_group_settings.remove(self.index)
+        return {'FINISHED'}
 
 
 @wrapper_registry

--- a/ui.py
+++ b/ui.py
@@ -452,13 +452,13 @@ class BakePanel(Panel):
             try:
                 sel = context.scene.bake_material_groups[context.scene.bake_material_groups_index]
                 groupnum = sel.group
-                op = row.operator(Create_Material_Group_Settings.bl_idname, text=f"Group {groupnum} Settings")
+                op = row.operator(Create_Material_Group_Settings.bl_idname, text=f"Override Group {groupnum} Settings")
                 op.group_number = groupnum
             except Exception:
                 pass
         # show group settings list
         row = col.row()
-        row.label(text='Group Settings')
+        row.label(text='Group Overrides')
         row = col.row()
         row.template_list('Material_Group_Settings_List', 'Group_Settings', context.scene, 'material_group_settings', context.scene, 'material_group_settings_index')
         col.separator()


### PR DESCRIPTION
Found some problematic materials which were causing issues with unmirror, but still wanted to use unmirror for the majority of my bake. This adds support for overriding the default option on a per-group basis.

Also added a fix for 4.5 since the alpha input for the composite node was removed. Doesn't appear to impact the outputs.

This PR is missing translations for the new ui components, feel free to edit or comment on as needed.