### PR TITLE
Drop Blender 2.x and 3.x support for 4.2.0+ only

### DIFF
--- a/bake.py
+++ b/bake.py
@@ -12,12 +12,9 @@ from .class_register import wrapper_registry
 from .tools.translate import t
 from .tools import core
 
-if bpy.app.version >= (4, 0, 0):
-    EMISSION_INPUT = "Emission Color"
-    SPECULAR_INPUT = "Specular IOR Level"
-else:
-    EMISSION_INPUT = "Emission"
-    SPECULAR_INPUT = "Specular"
+# Blender 4.2.0+ constants
+EMISSION_INPUT = "Emission Color"
+SPECULAR_INPUT = "Specular IOR Level"
 
 @wrapper_registry
 class BakeTutorialButton(bpy.types.Operator):
@@ -646,10 +643,7 @@ class BakeButton(bpy.types.Operator):
         context.scene.render.bake.use_pass_color = "COLOR" in bake_pass_filter
         context.scene.render.bake.use_pass_diffuse = "DIFFUSE" in bake_pass_filter
         context.scene.render.bake.use_pass_emit = "EMIT" in bake_pass_filter
-        if bpy.app.version >= (2, 92, 0):
-            context.scene.render.bake.target = "VERTEX_COLORS" if "VERTEX_COLORS" in bake_pass_filter else "IMAGE_TEXTURES"
-        if bpy.app.version <= (3, 0, 0):
-            context.scene.render.bake.use_pass_ambient_occlusion = "AO" in bake_pass_filter
+        context.scene.render.bake.target = "VERTEX_COLORS" if "VERTEX_COLORS" in bake_pass_filter else "IMAGE_TEXTURES"
         context.scene.cycles.samples = bake_samples
         context.scene.render.image_settings.color_mode = 'RGB'
         context.scene.render.bake.use_clear = clear and bake_type == 'NORMAL'
@@ -1269,10 +1263,7 @@ class BakeButton(bpy.types.Operator):
 
                 if pack_uvs:
                     if not context.scene.uvp_lock_islands:
-                        if bpy.app.version < (3, 6, 0) or not is_unittest:
-                            bpy.ops.uv.pack_islands(rotate=True, margin=margin)
-                        else:
-                            bpy.ops.uv.pack_islands(rotate=True, margin=margin, rotate_method="AXIS_ALIGNED")
+                        bpy.ops.uv.pack_islands(rotate=True, margin=margin, rotate_method="AXIS_ALIGNED")
 
                     # detect if UVPackMaster installed and configured: apparently UVP doesn't always
                     # self-initialize? So just force it
@@ -1415,10 +1406,7 @@ class BakeButton(bpy.types.Operator):
                                 bpy.ops.object.mode_set(mode='EDIT')
                                 
                                 print("Group " +str(group) + " selected. Packing islands")
-                                if bpy.app.version < (3, 6, 0) or not is_unittest:
-                                    bpy.ops.uv.pack_islands(rotate=True, margin=margin)
-                                else:
-                                    bpy.ops.uv.pack_islands(rotate=True, margin=margin, rotate_method="AXIS_ALIGNED")
+                                bpy.ops.uv.pack_islands(rotate=True, margin=margin, rotate_method="AXIS_ALIGNED")
                                 
                                 #deselect mesh geometry in preperation for next group
                                 bpy.ops.mesh.select_all(action='DESELECT')

--- a/tools/core.py
+++ b/tools/core.py
@@ -34,19 +34,8 @@ def get_tricount(obj):
     return len(bmesh_mesh.faces)
 
 def get_children_recursive(parent):
-    if bpy.app.version < (3, 1):
-        objs = []
-
-        def get_child_names(obj):
-            for child in obj.children:
-                objs.append(child)
-                if child.children:
-                    get_child_names(child)
-
-        get_child_names(parent)
-        return objs
-    else:
-        return parent.children_recursive
+    # Blender 4.2.0+ always has children_recursive
+    return parent.children_recursive
 
 def apply_shapekey_to_basis(context: bpy.types.Context, obj: bpy.types.Object, shape_key_name: str, delete_old: bool = False):
     if shape_key_name not in obj.data.shape_keys.key_blocks:
@@ -701,7 +690,8 @@ def duplicate_shapekey(string):
         return False
 
 def version_2_79_or_older():
-    return bpy.app.version < (2, 80)
+    # Always False for Blender 4.2.0+
+    return False
 
 #this is done because the version our addon is made for may not be minor or patch specific. In this case, just check what we specify for our version
 #This allows us to specify "(4, 0)" and ignore any 4.0.x version patches. - @989onan

--- a/ui.py
+++ b/ui.py
@@ -527,9 +527,6 @@ class BakePanel(Panel):
                 row.label(text=t('BakePanel.warn_no_cycles_addon'), icon="INFO")
                 row = col.row(align=True)
                     
-            if not addon_utils.check("render_auto_tile_size")[1] and bpy.app.version <= (2, 93):
-                row = col.row(align=True)
-                row.label(text=t('BakePanel.warn_auto_tile_size'), icon="INFO")
             row = col.row(align=True)
             row.prop(context.scene, 'bake_device', expand=True)
             

--- a/ui_sections/advanced_platform_options.py
+++ b/ui_sections/advanced_platform_options.py
@@ -110,9 +110,8 @@ class Bake_PT_advanced_platform_options:
                 row.separator()
                 row.prop(item, 'smoothness_premultiply_opacity', expand=True)
         if context.scene.bake_pass_diffuse:
-            if bpy.app.version >= (2, 92, 0):
-                row = col.row(align=True)
-                row.prop(item, 'diffuse_vertex_colors', expand=True)
+            row = col.row(align=True)
+            row.prop(item, 'diffuse_vertex_colors', expand=True)
         if context.scene.bake_pass_diffuse and (context.scene.bake_pass_smoothness or context.scene.bake_pass_alpha) and not item.diffuse_vertex_colors:
             row = col.row(align=True)
             row.label(text="Diffuse Alpha:")


### PR DESCRIPTION
- Remove version guards for Blender < 4.0.0
- Simplify EMISSION_INPUT/SPECULAR_INPUT to 4.x constants
- Remove bpy.app.version checks for 2.92, 3.0, 3.1, 3.4, 3.6
- Use AXIS_ALIGNED rotate method for all UV packing (3.6+)
- Simplify get_children_recursive to use children_recursive
- Remove auto tile size warning (2.93 only)