### PR TITLE
Fix plugin disable/re-enable cycle with centralized registration system

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,8 +3,8 @@ import os
 from .bake import BakeAddCopyOnly, BakeAddProp, BakeButton, BakePresetAll, BakePresetDesktop, BakePresetGmod, BakePresetGmodPhong, BakePresetQuest, BakePresetSecondlife, BakeRemoveCopyOnly, BakeRemoveProp, BakeTutorialButton
 from .ui import BakePanel, Bake_Lod_Delete, Bake_Lod_New, Bake_Platform_Delete, Bake_Platform_List, Bake_Platform_New, Choose_Steam_Library, Open_GPU_Settings, ToolPanel, SmartDecimation, FT_Shapes_UL
 
-from .class_register import order_classes, classes
-from .properties import set_steam_library
+from .class_register import register_all, unregister_all
+from .properties import set_steam_library, register_properties
 
 
 import glob
@@ -17,7 +17,6 @@ for module_name in [ basename(f)[:-3] for f in modules if isfile(f) and not f.en
 modules = glob.glob(join(dirname(__file__), "tools/*.py"))
 for module_name in [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]:
     exec("from .tools import "+module_name)
-from .properties import register_properties
 from bpy.types import Scene
 from sys import platform
 from .ui_sections.advanced_platform_options import Bake_PT_advanced_platform_options
@@ -26,29 +25,10 @@ from . import globals
 
 
 def register():
-    print("========= STARTING TUXEDO REGISTRY =========")
-    order_classes()
-    for cls in classes:
-        try:
-            bpy.utils.register_class(cls)
-            try:
-                print("registered class "+cls.bl_label)
-            except Exception as e:
-                print("tried to register class with no label.")
-                print(e)
-        except ValueError as e1:
-            try:
-                print("failed to register "+cls.bl_label)
-                print(e1)
-            except Exception as e2:
-                print("tried to register class with no label.")
-                print(e1)
-                print(e2)
-    classes.clear()
+    register_all()
     # Properties
     register_properties()
     custom_icons()
-    print("========= TUXEDO REGISTRY FINISHED =========")
     #needs to be after registering properties, because it accesses a property - @989onan
     print("========= READING STEAM REGISTRY KEYS FOR GMOD =========")
     
@@ -110,20 +90,9 @@ def custom_icons():
 
 
 def unregister():
-    print("========= DEREGISTERING TUXEDO =========")
-    for cls in classes:
-        try:
-            bpy.utils.unregister_class(cls)
-        except ValueError:
-            pass
-
-    for i, ft_shape in enumerate(SRanipal_Labels):
-        delattr(Scene, "ft_shapekey_" + str(i))
-
-    for i, ft_shape in enumerate(SRanipal_Labels):
-        delattr(Scene, "ft_shapekey_enable_" + str(i))
-    print("========= DEREGISTERING TUXEDO FINISHED =========")
-    bpy.utils.previews.remove(globals.icons_dict)
+    unregister_all()
+    if hasattr(globals, 'icons_dict'):
+        bpy.utils.previews.remove(globals.icons_dict)
 
 if __name__ == '__main__':
     register()

--- a/class_register.py
+++ b/class_register.py
@@ -1,15 +1,47 @@
 import bpy
 import typing
+from bpy.utils import register_class, unregister_class
 
 classes = []
 ordered_classes = []
+properties_registry = []  
+initial_scene_props = set()
+initial_object_props = set()
 
 #Stolen from cats. I will not pretend or say I made this - @989onan
 def wrapper_registry(class_obj):
     if hasattr(class_obj, 'bl_rna'):
         classes.append(class_obj)
     return class_obj
+
+def register_property(obj_type, prop_name, prop_def):
+    """Register a property and track it for cleanup"""
+    setattr(obj_type, prop_name, prop_def)
+    properties_registry.append((obj_type, prop_name))
+
+def _capture_initial_properties():
+    """Capture initial properties before registration"""
+    global initial_scene_props, initial_object_props
+    initial_scene_props = set(dir(bpy.types.Scene))
+    initial_object_props = set(dir(bpy.types.Object))
+
+def _track_new_properties():
+    """Find and track all newly added properties"""
+    global properties_registry
     
+    # Find new Scene properties
+    current_scene_props = set(dir(bpy.types.Scene))
+    new_scene_props = current_scene_props - initial_scene_props
+    for prop in new_scene_props:
+        if not prop.startswith('_'):
+            properties_registry.append((bpy.types.Scene, prop))
+    
+    # Find new Object properties  
+    current_object_props = set(dir(bpy.types.Object))
+    new_object_props = current_object_props - initial_object_props
+    for prop in new_object_props:
+        if not prop.startswith('_'):
+            properties_registry.append((bpy.types.Object, prop))
 
 def order_classes():
     deps_dict = {}
@@ -21,6 +53,131 @@ def order_classes():
     # Then put everything else sorted into the list
     for class_obj in toposort(deps_dict):
         ordered_classes.append(class_obj)
+
+def register_all():
+    """Register all classes and properties in correct order"""
+    print("========= STARTING TUXEDO REGISTRY =========")
+    
+    # On re-enable, use ordered_classes if classes is empty
+    if not classes and ordered_classes:
+        classes.extend(ordered_classes)
+    elif not classes:
+        # If both are empty, rebuild from modules
+        _rebuild_classes_from_modules()
+    
+    _capture_initial_properties()
+    if not ordered_classes:
+        order_classes()
+    
+    # Register classes (use ordered_classes if available)
+    classes_to_register = ordered_classes if ordered_classes else classes
+    for cls in classes_to_register:
+        try:
+            register_class(cls)
+            try:
+                print("registered class " + cls.bl_label)
+            except Exception as e:
+                print("tried to register class with no label.")
+                print(e)
+        except ValueError as e1:
+            if "already registered" in str(e1):
+                try:
+                    print(f"skipped already registered class {cls.bl_label}")
+                except:
+                    print(f"skipped already registered class")
+            else:
+                try:
+                    print("failed to register " + cls.bl_label)
+                    print(e1)
+                except Exception as e2:
+                    print("tried to register class with no label.")
+                    print(e1)
+                    print(e2)
+
+def _rebuild_classes_from_modules():
+    """Rebuild classes list by re-importing decorated modules"""
+    global classes
+    import importlib
+    import sys
+    import glob
+    from os.path import dirname, basename, isfile, join
+    
+    # Re-import key modules that contain @wrapper_registry decorators
+    try:
+        from . import bake
+        importlib.reload(bake)
+    except Exception as e:
+        print(f"Failed to reload bake: {e}")
+    
+    try:
+        from . import ui
+        importlib.reload(ui)
+    except Exception as e:
+        print(f"Failed to reload ui: {e}")
+    
+    # Reload all ui_sections
+    try:
+        ui_sections_path = join(dirname(__file__), "ui_sections")
+        modules = glob.glob(join(ui_sections_path, "*.py"))
+        for module_file in modules:
+            if isfile(module_file) and not module_file.endswith('__init__.py'):
+                module_name = basename(module_file)[:-3]
+                try:
+                    exec(f"from .ui_sections import {module_name}")
+                    mod = sys.modules.get(f"unofficial_tuxedo_blender_plugin.ui_sections.{module_name}")
+                    if mod:
+                        importlib.reload(mod)
+                except Exception as e:
+                    print(f"Failed to reload ui_sections.{module_name}: {e}")
+    except Exception as e:
+        print(f"Failed to reload ui_sections: {e}")
+    
+    # Reload all tools modules
+    try:
+        tools_path = join(dirname(__file__), "tools")
+        modules = glob.glob(join(tools_path, "*.py"))
+        for module_file in modules:
+            if isfile(module_file) and not module_file.endswith('__init__.py'):
+                module_name = basename(module_file)[:-3]
+                try:
+                    exec(f"from .tools import {module_name}")
+                    mod = sys.modules.get(f"unofficial_tuxedo_blender_plugin.tools.{module_name}")
+                    if mod:
+                        importlib.reload(mod)
+                except Exception as e:
+                    print(f"Failed to reload tools.{module_name}: {e}")
+    except Exception as e:
+        print(f"Failed to reload tools: {e}")
+
+def unregister_all():
+    """Unregister all classes and properties in reverse order"""
+    print("========= DEREGISTERING TUXEDO =========")
+    
+    # Track any new properties added since last registration
+    _track_new_properties()
+    
+    # Unregister classes in reverse order
+    for cls in reversed(classes):
+        try:
+            unregister_class(cls)
+        except (RuntimeError, ValueError) as e:
+            pass
+    
+    # Unregister properties in reverse order
+    for obj_type, prop_name in reversed(properties_registry):
+        if hasattr(obj_type, prop_name):
+            try:
+                delattr(obj_type, prop_name)
+            except Exception as e:
+                print(f"Failed to delete {obj_type.__name__}.{prop_name}: {e}")
+    
+    # Clear registries (do this AFTER trying to unregister, not before or ir causes issues)
+    classes.clear()
+    properties_registry.clear()
+    initial_scene_props.clear()
+    initial_object_props.clear()
+    
+    print("========= DEREGISTERING TUXEDO FINISHED =========")
 
 
 def iter_classes_to_register():

--- a/properties.py
+++ b/properties.py
@@ -7,6 +7,15 @@ from .tools.tools import SRanipal_Labels
 
 from .tools.translate import t
 from .ui import tab_enums
+from .class_register import register_property
+
+def safe_register_class(cls):
+    """Register a class, handling the case where it's already registered"""
+    try:
+        register_class(cls)
+    except ValueError as e:
+        if "already registered" not in str(e):
+            raise
 
 #this is basically a constant, set at launch. There is no reason to need to set this otherwise unless explictly giving only the user the option to do so.
 #this is set via the __init__ file and reads the steam libraries via registry keys at launch, so it will always
@@ -234,25 +243,25 @@ class BakePlatformPropertyGroup(PropertyGroup):
 
 def register_properties():
     # Bake
-    Scene.bake_use_draft_quality = BoolProperty(
+    register_property(Scene, 'bake_use_draft_quality', BoolProperty(
         name='Draft Quality',
         description=t('Scene.draft_quality_desc'),
         default=False
-    )
+    ))
 
-    Scene.smart_decimate_preserve_objects = BoolProperty(
+    register_property(Scene, 'smart_decimate_preserve_objects', BoolProperty(
         name=t('Scene.preserve_objects.label'),
         description=t('Scene.preserve_objects.desc'),
         default=False
-    )
+    ))
 
-    Scene.bake_animation_weighting = BoolProperty(
+    register_property(Scene, 'bake_animation_weighting', BoolProperty(
         name=t('Scene.decimation_animation_weighting.label'),
         description=t('Scene.decimation_animation_weighting.desc'),
         default=True
-    )
+    ))
 
-    Scene.bake_animation_weighting_factor = FloatProperty(
+    register_property(Scene, 'bake_animation_weighting_factor', FloatProperty(
         name=t('Scene.decimation_animation_weighting_factor.label'),
         description=t('Scene.decimation_animation_weighting_factor.desc'),
         default=0.25,
@@ -261,21 +270,21 @@ def register_properties():
         step=0.05,
         precision=2,
         subtype='FACTOR'
-    )
+    ))
 
-    Scene.bake_animation_weighting_include_shapekeys = BoolProperty(
+    register_property(Scene, 'bake_animation_weighting_include_shapekeys', BoolProperty(
         name=t('Tools.anim_weight_incl_shapekeys.name'),
         description=t('Tools.anim_weight_incl_shapekeys.desc'),
         default=False
-    )
+    ))
     
     
-    register_class(BakePlatformPropertyGroup)
+    safe_register_class(BakePlatformPropertyGroup)
 
-    Scene.bake_platforms = CollectionProperty(
+    register_property(Scene, 'bake_platforms', CollectionProperty(
         type=BakePlatformPropertyGroup
-    )
-    Scene.bake_platform_index = IntProperty(default=0)
+    ))
+    register_property(Scene, 'bake_platform_index', IntProperty(default=0))
     
 
     Scene.bake_cleanup_shapekeys = BoolProperty(
@@ -309,7 +318,7 @@ def register_properties():
             min=0,
             max=30
         )
-    register_class(MaterialListGrouper)
+    safe_register_class(MaterialListGrouper)
 
     class MaterialGroupSettings(PropertyGroup):
         group_number: IntProperty(
@@ -331,7 +340,7 @@ def register_properties():
             ],
             default="INHERIT",
         )
-    register_class(MaterialGroupSettings)
+    safe_register_class(MaterialGroupSettings)
     
     
     


### PR DESCRIPTION
- Implement centralized register_all() and unregister_all() functions in class_register.py
- Add automatic property detection and cleanup to prevent 'already registered' errors
- Preserve ordered_classes list across disable/enable cycles for reliable re-registration
- Add safe_register_class() helper in properties.py to handle already-registered classes
- Improve error handling in unregister_all() to continue even if individual unregistrations fail
- Remove unregister_properties.py as centralized system handles all cleanup
- Plugin now cleanly disables with no sidebar remnants and re-enables without errors

Closes #14 